### PR TITLE
fix(registerFontFromFile): add condition for 305 code duplicateName

### DIFF
--- a/ios/RNFontify.swift
+++ b/ios/RNFontify.swift
@@ -36,7 +36,7 @@ class RNFontify: NSObject {
           "ERR_FONT_REGISTRATION_UNKNOWN", "Failed to register font for unknown error", nil)
       }
 
-      if CTFontManagerError(rawValue: CFErrorGetCode(underlyingError)) == CTFontManagerError.alreadyRegistered
+      if CTFontManagerError(rawValue: CFErrorGetCode(underlyingError)) == CTFontManagerError.alreadyRegistered || CTFontManagerError(rawValue: CFErrorGetCode(underlyingError)) == CTFontManagerError.duplicatedName
       {
         return resolve(font.postScriptName as String?)
       }


### PR DESCRIPTION
this pr fixes error code 305 bug on ios, when font name is already exist